### PR TITLE
CPython: Global function not bind due to functions call order.

### DIFF
--- a/lang/cpython.py
+++ b/lang/cpython.py
@@ -689,11 +689,11 @@ const char *%s(PyObject *o) {
 	def finalize(self):
 		self._source += '// Module definitions starts here.\n\n'
 
-		methods_table = self.output_module_functions_table()
-		module_def = self.output_module_definition(methods_table)
-
 		# generic finalization
 		super().finalize()
+
+		methods_table = self.output_module_functions_table()
+		module_def = self.output_module_definition(methods_table)
 
 		self.output_binding_api()
 		self.output_module_init_function(module_def)

--- a/tests/struct_inheritance_cast.py
+++ b/tests/struct_inheritance_cast.py
@@ -1,0 +1,55 @@
+import lib
+
+
+def bind_test(gen):
+	gen.start('my_test')
+
+	lib.bind_defaults(gen)
+
+	# inject test code in the wrapper
+	gen.insert_code('''\
+struct base_class {
+};
+
+struct derived_class : base_class {
+	int u{7};
+};
+
+static derived_class __b;
+
+static base_class &GetBaseClass() {  return __b; }
+
+''', True, False)
+
+	base_conv =	gen.begin_class('base_class')
+	gen.bind_constructor(base_conv, [])
+	gen.end_class(base_conv)
+
+	derived_conv = gen.begin_class('derived_class')
+	gen.add_base(derived_conv, base_conv)
+	gen.bind_constructor(derived_conv, [])
+	gen.bind_members(derived_conv, ['int u'])
+	gen.end_class(derived_conv)
+
+	gen.bind_function('GetBaseClass', 'base_class &', [])
+
+	gen.finalize()
+
+	return gen.get_output()
+
+
+test_python = '''\
+import my_test
+
+a = my_test.GetBaseClass()
+b = my_test.Castbase_classToderived_class(a)
+assert b.u == 7
+'''
+
+test_lua = '''\
+my_test = require "my_test"
+
+a = my_test.GetBaseClass()
+b = my_test.Castbase_classToderived_class(a)
+assert(b.u == 7)
+'''


### PR DESCRIPTION
CPython: call the finalize function before calling output_module_functions_table because finalize call "bind_cast_functions" which add new global functions which are taking care by output_module_functions_table. (Like in lua.py)