### PR TITLE
Extern support

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -375,6 +375,7 @@ class FABGen:
 		self._header += '// FABgen output .h\n'
 		self._header += common
 		self._header += '#pragma once\n\n'
+		self._header += '#include <cstdint>\n\n'
 
 	def output_includes(self):
 		self.add_include('cstdint', True)
@@ -1255,6 +1256,7 @@ static void *_type_tag_cast(void *in_ptr, uint32_t in_type_tag, uint32_t out_typ
 		out += ' - %d types\n' % len(self.__type_convs)
 		out += ' - %d functions\n' % len(self._bound_functions)
 		out += ' - %d enums\n' % len(self._enums)
+		out += ' - %d extern types\n' % len(self._extern_types)
 
 		method_count, static_method_count, member_count, static_member_count = 0, 0, 0, 0
 

--- a/gen.py
+++ b/gen.py
@@ -396,6 +396,8 @@ class FABGen:
 		self._bound_variables = []  # list of bound variables
 		self._enums = {}  # list of bound enumerations
 
+		self._extern_types = []  # list of extern types
+
 		self._custom_init_code = ""
 		self._custom_free_code = ""
 
@@ -512,6 +514,28 @@ class FABGen:
 	def end_class(self, conv):
 		"""End a class declaration."""
 		self.end_type(conv)
+
+	#
+	def bind_extern_type(self, type):
+		"""Bind an external type."""
+		if type in self.__type_convs:
+			return self.__type_convs[type]  # type already declared
+
+		default_storage_type = type + '*'
+
+		conv = self.default_extern_converter(type, default_storage_type, None)
+
+		if self.verbose:
+			print('Binding extern type %s (%s)' % (conv.bound_name, conv.ctype))
+
+		self._header += conv.get_type_api(self._name)
+		self._source += conv.get_type_api(self._name)
+
+		self._extern_types.append(conv)
+		self.__type_convs[repr(conv.ctype)] = conv
+
+		self._source += conv.get_type_glue(self, self._name) + '\n'
+		return conv
 
 	#
 	def bind_ptr(self, type, converter_class=None, bound_name=None, features={}):

--- a/gen.py
+++ b/gen.py
@@ -375,7 +375,6 @@ class FABGen:
 		self._header += '// FABgen output .h\n'
 		self._header += common
 		self._header += '#pragma once\n\n'
-		self._header += '#include "fabgen.h"\n\n'
 
 	def output_includes(self):
 		self.add_include('cstdint', True)

--- a/lang/lua.py
+++ b/lang/lua.py
@@ -621,10 +621,55 @@ uint32_t %s(lua_State *L, int idx) {
 		self._source += '   return 0;\n'
 		self._source += '}\n\n'
 
+	def output_linker_api(self):
+		link_func = gen.apply_api_prefix('link_binding')
+
+		self._header += '''\
+/*
+	pass the get_c_type_info function from another binding to this function to resolve external types declared in this binding.
+	you will need to write a wrapper to cast the type_info * pointer to the correct type if you are using a binding prefix.
+	this function returns the number of unresolved external symbols.
+*/
+size_t %s(%s *(*get_c_type_info)(const char *));\n
+''' % (link_func, gen.apply_api_prefix('type_info'))
+
+		self._source += '''\
+size_t %s(%s *(*get_c_type_info)(const char *type)) {
+	size_t unresolved = 0;\n
+''' % (link_func, gen.apply_api_prefix('type_info'))
+
+		for extern_type in self._extern_types:
+			self._source += '''\
+	if (%s == nullptr) {
+		if (%s *info = (*get_c_type_info)("%s")) {
+			%s = info->check;
+			%s = info->to_c;
+			%s = info->from_c;
+		} else {
+			++unresolved;
+		}
+	}
+
+''' % (
+		extern_type.check_func,
+		gen.apply_api_prefix('type_info'),
+		extern_type.ctype,
+		extern_type.check_func,
+		extern_type.to_c_func,
+		extern_type.from_c_func
+	)
+
+		self._source += '''\
+	return unresolved;
+}
+
+'''
+
 	def finalize(self):
 		super().finalize()
 
 		self.output_binding_api()
+		self.output_linker_api()
 
 		# output module functions table
 		self._source += 'static const luaL_Reg %s_global_functions[] = {\n' % self._name


### PR DESCRIPTION
Functional support for external types in the Lua binding. CPython suport is lacking but is essentially the same thing as for Lua.