### PR TITLE
Incomplete unit test for extern types

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -43,8 +43,7 @@
 			"pythonPath": "${config:python.pythonPath}",
 			"program": "${workspaceRoot}/tests.py",
 			"cwd": "${workspaceRoot}",
-			"args": ["--pybase", "C:/Pythons/36-64", "--x64"],
-			"env": null,
+			"args": ["--pybase", "C:/Pythons/36", "--x64"],
 			"envFile": "${workspaceRoot}/.env",
 			"debugOptions": [
 				"WaitOnAbnormalExit",
@@ -60,8 +59,7 @@
 			"pythonPath": "${config:python.pythonPath}",
 			"program": "${workspaceRoot}/tests.py",
 			"cwd": "${workspaceRoot}",
-			"args": ["--pybase", "C:/Pythons/35-32", "--debug", "transform_rval"],
-			"env": null,
+			"args": ["--pybase", "C:/Pythons/36", "--debug", "extern_type", "--x64"],
 			"envFile": "${workspaceRoot}/.env",
 			"debugOptions": [
 				"WaitOnAbnormalExit",

--- a/api.py
+++ b/api.py
@@ -36,9 +36,6 @@ class DummyExternTypeConverter(gen.TypeConverter):
 
 		self.module = module  # store module
 
-		if module is not None:
-			self.bound_name = module + '.' + self.bound_name
-
 	def get_type_api(self, module_name):
 		return ''
 

--- a/tests/extern_type.py
+++ b/tests/extern_type.py
@@ -1,0 +1,25 @@
+# this test is incomplete and only ensures the output module builds
+
+import lib
+
+
+def bind_test(gen):
+	gen.start('my_test')
+
+	lib.bind_defaults(gen)
+
+	gen.bind_extern_type('SomeExternType')
+	gen.bind_extern_type('nspace::SomeOtherExternType', 'BoundAsThis')  # mostly for documentation purpose (so that extern types display the proper bound name)
+	gen.bind_extern_type('nspace::YetAnotherExternType', 'WithThisBoundName', 'TheModule')  # mostly for documentation purpose (so that extern types display the proper bound name)
+
+	gen.finalize()
+	return gen.get_output()
+
+
+test_python = '''\
+import my_test
+'''
+
+test_lua = '''\
+my_test = require "my_test"
+'''


### PR DESCRIPTION
- Add a basic and incomplete unit test to ensure that generated extern types support code builds.
- Do not append extern type module to the bound name as this breaks generated code on MSVC (the module parameter is kept as proper documentation support will be added shortly).